### PR TITLE
synchronize version table in docs/index.rst with readme.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ This app supports the following combinations of Django and Python:
 2.0         3.4, 3.5, 3.6, 3.7
 2.1         3.5, 3.6, 3.7
 2.2         3.5, 3.6, 3.7
+3.0         3.6, 3.7, 3.8
 ==========  =======================
 
 Contribute


### PR DESCRIPTION
## Description
I have copied the last row of the compatibility table in the readme.rst into docs/index.rst

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/633

## Motivation and Context
Updated Documentation

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change ~requires~ is a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
